### PR TITLE
Update build_docs.yml

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -29,6 +29,7 @@ jobs:
       # With the -s flag, it only builds Sphinx documentation
       - name: Build documentation website
         run: |
+          cd documentation
           .\build_docs.bat -s
 
       # Deploys the website to the gh-pages branch
@@ -36,4 +37,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: .\build\html
+          publish_dir: .\documentation\build\html


### PR DESCRIPTION
Fixed CI not being in documentation directory when it runs. Also updated the publish_dir to point to the documentation directory.