### PR TITLE
Add paper link to the advance article

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Documentation](https://rxnrover.github.io/RxnRover) | 
 [Plugin Catalog](https://rxnrover.github.io/PluginCatalog) | 
-Paper (not published) | 
+[Paper](https://doi.org/10.1039/D1RE00265A) | 
 [Team](https://rxnrover.github.io/)
 
 <img src="./assets/full_color_logo_3600x3600.jpg" alt="logo" width="300"/>


### PR DESCRIPTION
I added the link to the paper in the header of the README. This is the DOI link to the *Advance Article* at the moment.