### PR TITLE
Add support for 'Windows x64' OS name

### DIFF
--- a/Config/DefaultUserSettings.ini
+++ b/Config/DefaultUserSettings.ini
@@ -7,6 +7,7 @@ RTX=UNSUPPORTED
 Solaris=UNSUPPORTED
 VxWorks=UNSUPPORTED
 Windows NT=.rxnrover
+Windows x64=.rxnrover
 
 [Default File Locations]
 Linux=$HOME
@@ -17,3 +18,4 @@ RTX=UNSUPPORTED
 Solaris=UNSUPPORTED
 VxWorks=UNSUPPORTED
 Windows NT=%USERPROFILE%
+Windows x64=%USERPROFILE%


### PR DESCRIPTION
Fixes #8 by adding "Windows x64" as a supported return from the OS.name property.