### PR TITLE
Remove LabVIEW Runtime Install Instructions

### DIFF
--- a/documentation/source/user_resources/user_guide/installation.rst
+++ b/documentation/source/user_resources/user_guide/installation.rst
@@ -12,8 +12,18 @@ Installation
 Prerequisites
 -------------
 
-In order to run Rxn Rover, you need the free LabVIEW runtime engine,
-acquired from the `LabVIEW website <https://www.ni.com/en-us/support/downloads/software-products/download.labview-runtime.html#369481>`__ or a developer version of LabVIEW.
+.. In order to run Rxn Rover, you need the free LabVIEW runtime engine,
+.. acquired from the `LabVIEW website 
+.. <https://www.ni.com/en-us/support/downloads/software-products/download.labview-runtime.html#369481>`__ 
+.. or a developer version of LabVIEW.
+
+In order to run Rxn Rover, you need to acquire a `developer version of LabVIEW
+<https://www.ni.com/en-us/shop/product/labview.html>`__. We are working on an
+executable version that can be run with the free `LabVIEW runtime engine
+<https://www.ni.com/en-us/support/downloads/software-products/download.labview-runtime.html#369481>`__,
+but the dynamic nature of Rxn Rover has made this step difficult to implement.
+
+.. Rxn Rover releases page, where the executable will be once it is complete: https://github.com/RxnRover/RxnRover/releases
 
 You also need the Dynamic Reentrant library, developed by the Rxn Rover team
 to facilitate communication between Rxn Rover and its plugins. It can be 


### PR DESCRIPTION
Rxn Rover currently can only be run from source code, meaning that a development version of LabVIEW is needed to run it. The LabVIEW runtime environment can only run executables built from LabVIEW, but, due to a misunderstanding early in the project, I thought it could also execute VIs in a "read-only" mode and it was included in the installation instructions prematurely. The dynamic nature of Rxn Rover has made creating a functioning executable version difficult, and it is still in development.

This PR fixes the installation instructions to accurately reflect the current installation and usage requirements.