### PR TITLE
Documentation Deployment Fix

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -25,7 +25,8 @@ jobs:
       # Deploys the website to the gh-pages branch
       - name: Deploy to GitHub Pages
         # Trigger on push to the default branch (usually 'master' or 'main')
-        if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
+        # as well as if triggered manually with a workspace dispatch event.
+        if: ${{ github.ref_name == github.event.repository.default_branch && (github.event_name == 'push' || github.event_name == 'workspace_dispatch') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -24,6 +24,8 @@ jobs:
 
       # Deploys the website to the gh-pages branch
       - name: Deploy to GitHub Pages
+        # Trigger on push to the default branch (usually 'master' or 'main')
+        if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Deploy to GitHub Pages
         # Trigger on push to the default branch (usually 'master' or 'main')
         # as well as if triggered manually with a workspace dispatch event.
-        if: ${{ github.ref_name == github.event.repository.default_branch && (github.event_name == 'push' || github.event_name == 'workspace_dispatch') }}
+        if: ${{ github.ref_name == github.event.repository.default_branch && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The `build-and-deploy-docs` workflow should only deploy the new docs on a push or PR merge into the default branch. Right now, the deployment happens every time the workflow is run, even when run as a check on an open PR where only the build test portion should run. This PR fixes this by making the deployment step conditional on a push even to the default branch. It is also set up to run when the action is manually triggered via `workflow_dispatch`.

## Related Issues/Pull Requests

Fixes #21 

## Todos

- [x] Does this skip the deployment step on an open PR?
- [ ] Does this properly trigger when a PR is merged?
